### PR TITLE
Fix change in RestChannel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.0</version>
     </parent>
 
     <groupId>org.elasticsearch</groupId>

--- a/src/main/java/org/elasticsearch/wares/AbstractServletRestChannel.java
+++ b/src/main/java/org/elasticsearch/wares/AbstractServletRestChannel.java
@@ -33,8 +33,8 @@ import java.io.IOException;
  */
 abstract class AbstractServletRestChannel extends RestChannel {
 
-    protected AbstractServletRestChannel(RestRequest request) {
-        super(request);
+    protected AbstractServletRestChannel(RestRequest request, boolean detailedErrorsEnabled) {
+        super(request, detailedErrorsEnabled);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/wares/AsyncNodeServlet.java
+++ b/src/main/java/org/elasticsearch/wares/AsyncNodeServlet.java
@@ -48,7 +48,8 @@ public class AsyncNodeServlet extends NodeServlet {
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         final AsyncContext asyncContext = req.startAsync();
         ServletRestRequest request = new ServletRestRequest(req);
-        AsyncServletRestChannel channel = new AsyncServletRestChannel(request, asyncContext);
+        AsyncServletRestChannel channel = new AsyncServletRestChannel(request, asyncContext,
+                detailedErrorsEnabled);
         restController.dispatchRequest(request, channel);
     }
 
@@ -56,8 +57,8 @@ public class AsyncNodeServlet extends NodeServlet {
 
         final AsyncContext asyncContext;
 
-        AsyncServletRestChannel(RestRequest restRequest, AsyncContext asyncContext) {
-            super(restRequest);
+        AsyncServletRestChannel(RestRequest restRequest, AsyncContext asyncContext, boolean detailedErrorsEnabled) {
+            super(restRequest, detailedErrorsEnabled);
             this.asyncContext = asyncContext;
         }
 

--- a/src/main/java/org/elasticsearch/wares/NodeServlet.java
+++ b/src/main/java/org/elasticsearch/wares/NodeServlet.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.wares;
 
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.http.netty.NettyHttpServerTransport;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.node.internal.InternalNode;
@@ -53,6 +54,8 @@ public class NodeServlet extends HttpServlet {
     protected Node node;
 
     protected RestController restController;
+    
+    protected boolean detailedErrorsEnabled;
 
     @Override
     public void init() throws ServletException {
@@ -111,7 +114,8 @@ public class NodeServlet extends HttpServlet {
             getServletContext().log("Using pre-initialized elasticsearch Node '" + getServletName() + "'");
             this.node = (InternalNode) nodeAttribute;
         }
-        restController = ((InternalNode) node).injector().getInstance(RestController.class);
+        restController = ((InternalNode) node).injector().getInstance(RestController.class);        
+        detailedErrorsEnabled = ((InternalNode) this.node).settings().getAsBoolean(NettyHttpServerTransport.SETTING_HTTP_DETAILED_ERRORS_ENABLED, true);
     }
 
     @Override
@@ -125,7 +129,7 @@ public class NodeServlet extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         ServletRestRequest request = new ServletRestRequest(req);
-        ServletRestChannel channel = new ServletRestChannel(request, resp);
+        ServletRestChannel channel = new ServletRestChannel(request, resp, this.detailedErrorsEnabled);
         try {
             restController.dispatchRequest(request, channel);
             channel.latch.await();
@@ -145,8 +149,8 @@ public class NodeServlet extends HttpServlet {
 
         IOException sendFailure;
 
-        ServletRestChannel(RestRequest restRequest, HttpServletResponse resp) {
-            super(restRequest);
+        ServletRestChannel(RestRequest restRequest, HttpServletResponse resp, boolean detailedErrorsEnabled) {
+            super(restRequest, detailedErrorsEnabled);
             this.resp = resp;
             this.latch = new CountDownLatch(1);
         }


### PR DESCRIPTION
`RestChannel` now has a parameter `detailedErrorsEnabled` which wasn't being passed in, causing a `NoSuchMethodError` if you try to run it with elasticsearch 1.5 (and a compile error if you tried to compile it).

See also https://github.com/elastic/elasticsearch/pull/10117