### PR TITLE
[test] add unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,14 @@
             <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Jetty servlet tester -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>test-jetty-servlet</artifactId>
+            <version>8.1.9.v20130131</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/elasticsearch/wares/NodeServlet.java
+++ b/src/main/java/org/elasticsearch/wares/NodeServlet.java
@@ -60,6 +60,7 @@ public class NodeServlet extends HttpServlet {
     public void init() throws ServletException {
         final Object nodeAttribute = getServletContext().getAttribute(NODE_KEY);
         if (nodeAttribute == null) {
+            // TODO check this. It does not make sense. If nodeAttribute == null it can't be != null
             if (nodeAttribute != null) {
                 getServletContext().log(
                         "Warning: overwriting attribute with key \"" + NODE_KEY + "\" and type \""
@@ -113,7 +114,7 @@ public class NodeServlet extends HttpServlet {
             getServletContext().log("Using pre-initialized elasticsearch Node '" + getServletName() + "'");
             this.node = (Node) nodeAttribute;
         }
-        restController = ((Node) node).injector().getInstance(RestController.class);        
+        restController = node.injector().getInstance(RestController.class);
         detailedErrorsEnabled = this.node.settings().getAsBoolean(NettyHttpServerTransport.SETTING_HTTP_DETAILED_ERRORS_ENABLED, true);
     }
 

--- a/src/test/java/org/elasticsearch/wares/NodeServletTest.java
+++ b/src/test/java/org/elasticsearch/wares/NodeServletTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.wares;
+
+
+import org.elasticsearch.node.Node;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.eclipse.jetty.testing.HttpTester;
+import org.eclipse.jetty.testing.ServletTester;
+
+import static org.hamcrest.Matchers.*;
+
+public class NodeServletTest extends ElasticsearchTestCase {
+
+    protected ServletTester tester;
+
+    @Before
+    public void initServletTester() throws Exception {
+        String tmpPath = tmpPaths()[0];
+        tester = new ServletTester();
+        tester.setContextPath("/elasticsearch");
+        tester.addServlet(NodeServlet.class, "/*");
+        tester.setAttribute(NodeServlet.NAME_PREFIX + "path.home", tmpPath);
+        tester.setAttribute(NodeServlet.NAME_PREFIX + "node.name", "wares-node");
+        tester.setAttribute(NodeServlet.NAME_PREFIX + "cluster.name", "wares-cluster");
+        tester.start();
+    }
+
+    @After
+    public void destroyServletTester() throws Exception {
+        if (tester != null) {
+            tester.stop();
+            // We need to wait a while for all threads to be stopped
+            Thread.sleep(1000L);
+        }
+    }
+
+    @Test
+    public void elasticsearchRunning() throws Exception {
+        elasticsearchEndpointTester("/elasticsearch/", 200, "cluster_name");
+        elasticsearchEndpointTester("/elasticsearch/_cat/", 200, "_cat/master");
+        elasticsearchEndpointTester("/elasticsearch/_cat/health", 200, "wares-cluster");
+        elasticsearchEndpointTester("/elasticsearch/_cat/nodes", 200, "wares-node");
+        Object attribute = tester.getContext().getServletContext().getContext("/elasticsearch").getAttribute(NodeServlet.NODE_KEY);
+        assertThat(attribute, instanceOf(Node.class));
+    }
+
+    protected void elasticsearchEndpointTester(String url, int expectedCode, String expectedContent) throws Exception {
+        HttpTester request = new HttpTester();
+        request.setMethod("GET");
+        request.setHeader("Host","tester");
+        request.setURI(url);
+        request.setVersion("HTTP/1.0");
+
+        HttpTester response = new HttpTester();
+        response.parse(tester.getResponses(request.generate()));
+
+        assertThat(response.getStatus(), is(expectedCode));
+        assertThat(response.getContent(), containsString(expectedContent));
+    }
+
+}

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <priority value ="info" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
Wares plugin does not have any test yet.
This first commit add some infra using `jetty-servlet-tester` and a first test which:
- launch a `ServletTester`
- set `path.home`, `node.name` and `cluster.name`
- test `/elasticsearch/` url
- test `/elasticsearch/_cat/` url
- test `/elasticsearch/_cat/health` url and check cluster name
- test `/elasticsearch/_cat/nodes` url and check node name
- check that we can access `Node` object from servlet context using `elasticsearchNode` key
